### PR TITLE
development-v4: symlink to default development

### DIFF
--- a/development-v4.json
+++ b/development-v4.json
@@ -1,0 +1,1 @@
+development.json


### PR DESCRIPTION
Add an extra symlink `development-v4`  which points to `development` for now.