### PR TITLE
development-v4: symlink doesn't works with github raw requests

### DIFF
--- a/development-v4.json
+++ b/development-v4.json
@@ -1,1 +1,63 @@
-development.json
+{
+    "yggdrasil": {
+        "peers": [
+            "tls://163.172.31.60:12221?key=060f2d49c6a1a2066357ea06e58f5cff8c76a5c0cc513ceb2dab75c900fe183b&sni=jorropo.net",
+            "tls://jorropo.net:12221?key=060f2d49c6a1a2066357ea06e58f5cff8c76a5c0cc513ceb2dab75c900fe183b&sni=jorropo.net",
+            "tcp://gent01.grid.tf:9943",
+            "tcp://gent02.grid.tf:9943",
+            "tcp://gent03.grid.tf:9943",
+            "tcp://gent04.grid.tf:9943",
+            "tcp://gent01.test.grid.tf:9943",
+            "tcp://gent02.test.grid.tf:9943",
+            "tcp://gent01.dev.grid.tf:9943",
+            "tcp://gent02.dev.grid.tf:9943",
+            "tcp://gw291.vienna1.greenedgecloud.com:9943",
+            "tcp://gw293.vienna1.greenedgecloud.com:9943",
+            "tcp://gw294.vienna1.greenedgecloud.com:9943",
+            "tcp://gw297.vienna1.greenedgecloud.com:9943",
+            "tcp://gw298.vienna1.greenedgecloud.com:9943",
+            "tcp://gw299.vienna2.greenedgecloud.com:9943",
+            "tcp://gw300.vienna2.greenedgecloud.com:9943",
+            "tcp://gw304.vienna2.greenedgecloud.com:9943",
+            "tcp://gw306.vienna2.greenedgecloud.com:9943",
+            "tcp://gw307.vienna2.greenedgecloud.com:9943",
+            "tcp://gw309.vienna2.greenedgecloud.com:9943",
+            "tcp://gw313.vienna2.greenedgecloud.com:9943",
+            "tcp://gw324.salzburg1.greenedgecloud.com:9943",
+            "tcp://gw326.salzburg1.greenedgecloud.com:9943",
+            "tcp://gw327.salzburg1.greenedgecloud.com:9943",
+            "tcp://gw328.salzburg1.greenedgecloud.com:9943",
+            "tcp://gw330.salzburg1.greenedgecloud.com:9943",
+            "tcp://gw331.salzburg1.greenedgecloud.com:9943",
+            "tcp://gw333.salzburg1.greenedgecloud.com:9943",
+            "tcp://gw422.vienna2.greenedgecloud.com:9943",
+            "tcp://gw423.vienna2.greenedgecloud.com:9943",
+            "tcp://gw424.vienna2.greenedgecloud.com:9943",
+            "tcp://gw425.vienna2.greenedgecloud.com:9943"
+        ]
+    },
+    "mycelium": {
+        "peers": [
+            "tcp://188.40.132.242:9651",
+            "tcp://136.243.47.186:9651",
+            "tcp://185.69.166.7:9651",
+            "tcp://185.69.166.8:9651",
+            "tcp://65.21.231.58:9651",
+            "tcp://65.109.18.113:9651"
+        ]
+    },
+    "users": {
+        "authorized": [
+            "muhamadazmy",
+            "delandtj",
+            "maxux",
+            "LeeSmet",
+            "coesensbert",
+            "ashraffouda",
+            "AbdelrahmanElawady",
+            "Omarabdul3ziz",
+            "rawdaGastan",
+            "Eslam-Nawara"
+        ]
+    }
+}


### PR DESCRIPTION
When trying to reach raw content of a symlink, content is the target link (which makes sens) but symlink is not followed, so we can't use that directly. I just copied the file.