### PR TITLE
update services urls

### DIFF
--- a/development.json
+++ b/development.json
@@ -69,16 +69,20 @@
         "test_farms": []
     },
     "relays_urls": [
-        "wss://relay.dev.threefold.me"
+        "wss://relay.dev.threefold.me",
+        "wss://relay.dev.grid.tf"
     ],
     "substrate_urls": [
-        "wss://tfchain.dev.threefold.me/"
+        "wss://tfchain.dev.threefold.me/",
+        "wss://tfchain.dev.grid.tf/"
     ],
     "activation_urls": [
-        "https://activation.dev.threefold.me/activation/activate"
+        "https://activation.dev.threefold.me/activation/activate",
+        "https://activation.dev.grid.tf/activation/activate"
     ],
     "graphql_urls": [
-        "https://graphql.dev.threefold.me/graphql"
+        "https://graphql.dev.threefold.me/graphql",
+        "https://graphql.dev.grid.tf/graphql"
     ],
     "geoip_urls": [
         "https://geoip.grid.tf/",
@@ -87,10 +91,12 @@
         "https://geoip.threefold.me/"
     ],
     "hub_urls": [
-        "https://hub.threefold.me"
+        "https://hub.threefold.me",
+        "https://hub.grid.tf"
     ],
     "v4_hub_urls": [
-        "https://v4.hub.threefold.me"
+        "https://v4.hub.threefold.me",
+        "https://v4.hub.grid.tf"
     ],
     "flist_url": "redis://hub.threefold.me:9900",
     "bin_repo": "tf-zos-v3-bins",

--- a/production.json
+++ b/production.json
@@ -51,7 +51,10 @@
         ]
     },
     "rollout_upgrade": {
-        "test_farms": [1, 3997]
+        "test_farms": [
+            1,
+            3997
+        ]
     },
     "relays_urls": [
         "wss://relay.grid.tf"
@@ -66,10 +69,16 @@
     ],
     "graphql_urls": [
         "https://graphql.grid.threefold.me/graphql",
-        "https://graphql.grid.tf/graphql",
+        "https://graphql.grid.tf/graphql"
     ],
-    "hub_url": ["https://hub.threefold.me"],
-    "flist_url": ["redis://hub.threefold.me:9900"],
+    "hub_url": [
+        "https://hub.threefold.me",
+        "https://hub.grid.tf"
+    ],
+    "flist_url": [
+        "redis://hub.threefold.me:9900",
+        "redis://hub.grid.tf:9900"
+    ],
     "bin_repo": "tf-zos-v3-bins",
     "kyc_url": "https://kyc.threefold.me",
     "registrar_url": "https://registrar.prod4.grid.tf"

--- a/production.json
+++ b/production.json
@@ -51,7 +51,10 @@
         ]
     },
     "rollout_upgrade": {
-        "test_farms": [1, 3997]
+        "test_farms": [
+            1,
+            3997
+        ]
     },
     "relays_urls": [
         "wss://relay.grid.tf"
@@ -68,10 +71,15 @@
         "https://graphql.grid.threefold.me/graphql",
         "https://graphql.grid.tf/graphql"
     ],
-    "hub_url": ["https://hub.threefold.me"],
-    "flist_url": ["redis://hub.threefold.me:9900"],
+    "hub_url": [
+        "https://hub.threefold.me",
+        "https://hub.grid.tf"
+    ],
+    "flist_url": [
+        "redis://hub.threefold.me:9900",
+        "redis://hub.grid.tf:9900"
+    ],
     "bin_repo": "tf-zos-v3-bins",
     "kyc_url": "https://kyc.threefold.me",
     "registrar_url": "https://registrar.prod4.grid.tf"
 }
-

--- a/qa.json
+++ b/qa.json
@@ -61,30 +61,46 @@
             "AbdelrahmanElawady",
             "Omarabdul3ziz",
             "rawdaGastan",
-            "Eslam-Nawara"
+            "Eslam-Nawara",
+            "hossnys",
+            "PeterNashaat"
         ]
     },
     "rollout_upgrade": {
-        "test_farms": [190, 1, 43]
+        "test_farms": [
+            190,
+            1,
+            43
+        ]
     },
     "relays_urls": [
-        "wss://relay.qa.grid.tf"
+        "wss://relay.qa.grid.tf",
+        "wss://relay.qa.threefold.me"
     ],
     "substrate_urls": [
         "wss://tfchain.qa.grid.tf/",
-        "wss://tfchain.02.qa.grid.tf/"
+        "wss://tfchain.qa.threefold.me/"
     ],
     "activation_urls": [
         "https://activation.qa.grid.tf/activation/activate",
-        "https://activation.02.qa.grid.tf/activation/activate"
+        "https://activation.qa.threefold.me.activation/activate"
     ],
     "graphql_urls": [
         "https://graphql.qa.grid.tf/graphql",
-        "https://graphql.02.qa.grid.tf/graphql"
+        "https://graphql.qa.threefold.me/graphql"
     ],
-    "hub_url": ["https://hub.threefold.me"],
-    "v4hub_url": ["https://v4.hub.threefold.me", "https://v4.hub.grid.tf"],
-    "flist_url": ["redis://hub.grid.tf:9900"],
+    "hub_url": [
+        "https://hub.threefold.me",
+        "https://hub.grid.tf"
+    ],
+    "v4hub_url": [
+        "https://v4.hub.threefold.me",
+        "https://v4.hub.grid.tf"
+    ],
+    "flist_url": [
+        "redis://hub.grid.tf:9900",
+        "redis://hub.threefold.me:9900"
+    ],
     "bin_repo": "tf-zos-v3-bins.qanet",
     "kyc_url": "https://kyc.qa.grid.tf",
     "registrar_url": "https://registrar.qa4.grid.tf"

--- a/testing.json
+++ b/testing.json
@@ -67,22 +67,39 @@
         ]
     },
     "rollout_upgrade": {
-        "test_farms": [1]
+        "test_farms": [
+            1,
+            373
+        ]
     },
     "relays_urls": [
-        "wss://relay.test.grid.tf"
+        "wss://relay.test.grid.tf",
+        "wss://relay.test.threefold.me"
     ],
     "substrate_urls": [
-        "wss://tfchain.test.grid.tf/"
+        "wss://tfchain.test.grid.tf/",
+        "wss://tfchain.test.threefold.me/"
     ],
     "activation_urls": [
-        "https://activation.test.grid.tf/activation/activate"
+        "https://activation.test.grid.tf/activation/activate",
+        "https://activation.test.threefold.me/activation/activate"
     ],
     "graphql_urls": [
-        "https://graphql.test.grid.tf/graphql"
+        "https://graphql.test.grid.tf/graphql",
+        "https://graphql.test.threefold.me/graphql"
     ],
-    "hub_url": ["https://hub.threefold.me"],
-    "flist_url": ["redis://hub.grid.tf:9900"],
+    "hub_url": [
+        "https://hub.threefold.me",
+        "https://hub.grid.tf"
+    ],
+    "v4hub_url": [
+        "https://v4.hub.threefold.me",
+        "https://v4.hub.grid.tf"
+    ],
+    "flist_url": [
+        "redis://hub.grid.tf:9900",
+        "redis://hub.threefold.me:9900"
+    ],
     "bin_repo": "tf-zos-v3-bins.test",
     "kyc_url": "https://kyc.test.grid.tf",
     "registrar_url": "http://registrar.test4.grid.tf"


### PR DESCRIPTION
- add Liria farm to testnet rollout_upgrade.
- add more services urls as backup url for running services.